### PR TITLE
Fixed version for diesel 3.0

### DIFF
--- a/legendary_skins.lua
+++ b/legendary_skins.lua
@@ -1,0 +1,86 @@
+-- Purpose: Gives you all skins
+-- Authors: Written by Simplity, fixes by Davy Jones/yazeedoo
+-- Performance fix: stop the persist script after initialization.
+
+local tostring = tostring
+local type = type
+
+local M_blackmarket = managers.blackmarket
+local weapon_skins = tweak_data.blackmarket.weapon_skins
+local inventory_tradable = M_blackmarket._global.inventory_tradable
+
+local i = 1
+local j = tostring(i)
+
+for id, data in pairs(weapon_skins) do
+    if not string.find(id, "color") then
+        while inventory_tradable[j] ~= nil do
+            i = i + 1
+            j = tostring(i)
+        end
+
+        if not M_blackmarket:have_inventory_tradable_item(
+            "weapon_skins",
+            id
+        ) then
+            M_blackmarket:tradable_add_item(
+                j,
+                "weapon_skins",
+                id,
+                "mint",
+                true,
+                1
+            )
+        end
+    end
+end
+
+-- Temporary fix for the temporary fix
+local convert
+
+convert = function()
+    for inst, data in pairs(inventory_tradable) do
+        if type(inst) == "number" then
+            inventory_tradable[tostring(inst)] = data
+            inventory_tradable[inst] = nil
+        end
+    end
+
+    convert = nil
+end
+
+function BlackMarketManager:tradable_update()
+    if convert then
+        convert()
+    end
+end
+
+-- Modifiable Legendary Skins
+for id, data in pairs(weapon_skins) do
+    if not string.find(id, "color") then
+        data.locked = false
+    end
+end
+
+local crafted = M_blackmarket._global.crafted_items
+
+for _, category in pairs({
+    crafted.primaries,
+    crafted.secondaries
+}) do
+    for _, data in pairs(category) do
+        if data.cosmetics then
+            data.customize_locked = nil
+        end
+    end
+end
+
+-- Inspect All Safes
+for _, safe in pairs(tweak_data.economy.safes) do
+    if not safe.market_link then
+        safe.market_link = "Fake Link"
+    end
+end
+
+-- Required by the original persist_scripts manifest.
+_G["Legendary Skins"] = true


### PR DESCRIPTION
Added _G["Legendary Skins"] = true so SuperBLT stops rerunning the persist script every frame, which stops the repeated inventory, skin, crafted-weapon, and safe-table processing that caused the FPS loss. The original ownership and compatibility logic is the same as the original 